### PR TITLE
Restore eslint v1.x behaviour for keyword-spacing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ module.exports = {
     'no-new-object': 2,
     'no-spaced-func': 2,
     'no-mixed-spaces-and-tabs': 2,
-    'keyword-spacing': [2, { 'before': false, 'after': true }],
+    'keyword-spacing': [2, { 'before': true, 'after': true }],
     'semi': [2, 'always'],
     'semi-spacing': [2, { 'before': false, 'after': true }],
     'space-infix-ops': 2,


### PR DESCRIPTION
See #31.