### PR TITLE
allow backticks for strings with single quotes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ module.exports = {
     'arrow-parens': ['error', 'always'],
     'arrow-spacing': ['error', { before: true, after: true }],
     'hapi/no-arrowception': 'error',
-    'quotes': ['error', 'single'],
+    'quotes': ['error', 'single', { allowTemplateLiterals: true }],
     'consistent-this': ['error', 'self'],
     'new-parens': 'error',
     'no-array-constructor': 'error',


### PR DESCRIPTION
this makes a string like

```js
const str = `this string has 'single quotes'`;
```

not error, previously you would've had to do

```js
const str = 'this string has \'single quotes\'';
```

which is ugly and i don't like it.

thoughts?